### PR TITLE
LYJ-606: Skip get device description errors when enumerating usb devices

### DIFF
--- a/usb.go
+++ b/usb.go
@@ -176,7 +176,8 @@ func (c *Context) OpenDevices(opener func(desc *DeviceDesc) bool) ([]*Device, er
 		desc, err := c.libusb.getDeviceDesc(dev)
 		if err != nil {
 			c.libusb.dereference(dev)
-			reterr = err
+			debug.Printf("Skipping Error: %v", err)
+			//reterr = err
 			continue
 		}
 


### PR DESCRIPTION
@IvoBCD Please review

Initial simple fix